### PR TITLE
Move quick stats bar to top

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,26 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
+  <!-- Quick Stats Bar (Top Center) -->
+  <div id="quickStatsUI">
+    <div class="stat-item">
+      <span class="stat-label">Active Meteors:</span>
+      <span class="stat-value" id="meteorCount">0</span>
+    </div>
+    <div class="stat-item">
+      <span class="stat-label">Total Impacts:</span>
+      <span class="stat-value" id="impactCount">0</span>
+    </div>
+    <div class="stat-item">
+      <span class="stat-label">Last Impact Energy:</span>
+      <span class="stat-value" id="impactEnergy">-</span>
+    </div>
+    <div class="stat-item">
+      <span class="stat-label">Simulation Time:</span>
+      <span class="stat-value" id="simTime">0.0s</span>
+    </div>
+  </div>
+
   <!-- Camera Focus UI (Top Right) -->
   <div id="cameraFocusUI">
     <h3>Camera Focus</h3>
@@ -114,12 +134,6 @@
       <button id="pause">Pause</button>
       <button id="toggleAiming">Hide Aiming</button>
       <button id="fire">Fire</button>
-    </div>
-    <div class="counters">
-      <div>Active Meteors: <span id="meteorCount">0</span></div>
-      <div>Total Impacts: <span id="impactCount">0</span></div>
-      <div>Last Impact Energy: <span id="impactEnergy">-</span></div>
-      <div>Simulation Time: <span id="simTime">0.0s</span></div>
     </div>
     <hr>
 

--- a/styles.css
+++ b/styles.css
@@ -2,6 +2,45 @@
 body { margin: 0; font-family: Inter, system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial; background: #0b1020; color: #e6eef8; }
 canvas { display:block; }
 
+/* Quick Stats Bar (Top Center) */
+#quickStatsUI {
+  position: absolute;
+  top: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 20px;
+  background: linear-gradient(180deg, rgba(20,24,36,0.9), rgba(12,14,22,0.85));
+  color: #e6eef8;
+  padding: 12px 20px;
+  box-sizing: border-box;
+  z-index: 20;
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.6), inset 0 1px 0 rgba(255,255,255,0.02);
+  backdrop-filter: blur(6px) saturate(120%);
+}
+
+.stat-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 80px;
+}
+
+.stat-label {
+  font-size: 10px;
+  color: #b9cfe6;
+  margin-bottom: 2px;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.stat-value {
+  font-size: 13px;
+  color: #e6eef8;
+  font-weight: 600;
+}
+
 /* Camera Focus UI (Top Right) */
 #cameraFocusUI {
   position: absolute;
@@ -337,7 +376,6 @@ kbd {
 .small { font-size: 12px; color: #b9cfe6; margin-bottom: 8px; }
 .button-row { display:flex; gap:8px; }
 .button-row button { flex:1; }
-.counters { margin-top:8px; color:#cfe6ff; font-size:13px; }
 
 .label { position: absolute; pointer-events: none; font-size:12px; padding:4px 8px; background: rgba(0,0,0,0.6); border-radius:6px; border: 1px solid rgba(255,255,255,0.03); color: #fff; transform: translate(-50%, -140%); white-space: nowrap; }
 
@@ -348,7 +386,7 @@ kbd {
     color: #e8f0ff;
   }
   
-  #ui, #cameraFocusUI, #statsUI, #mapUI, #statisticsUI, #helpUI {
+  #ui, #cameraFocusUI, #statsUI, #mapUI, #statisticsUI, #helpUI, #quickStatsUI {
     background: linear-gradient(180deg, rgba(15,18,28,0.95), rgba(8,10,16,0.9));
     border: 1px solid rgba(255,255,255,0.05);
   }
@@ -451,5 +489,26 @@ kbd {
     width: calc(100vw - 20px);
     right: 10px;
     bottom: 10px;
+  }
+  
+  /* Quick stats bar responsive */
+  #quickStatsUI {
+    flex-direction: column;
+    gap: 8px;
+    top: 10px;
+    padding: 10px 16px;
+    max-width: calc(100vw - 20px);
+  }
+  
+  .stat-item {
+    min-width: auto;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+  }
+  
+  .stat-label {
+    margin-bottom: 0;
+    text-align: left;
   }
 }


### PR DESCRIPTION
Move the quick stats bar to the top of the interface to improve visibility and UI organization.

---
<a href="https://cursor.com/background-agent?bcId=bc-eaf49b4e-c54a-4281-b4bc-e810db6229e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eaf49b4e-c54a-4281-b4bc-e810db6229e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

